### PR TITLE
z-loading组件由隐藏变为显示时会清除上一次延迟隐藏的计时器，避免短时间内状态多次变化导致的加载中界面被错误隐藏的情况。

### DIFF
--- a/z-angular-loading.js
+++ b/z-angular-loading.js
@@ -14,6 +14,7 @@ angular
         zLoading:'='
       },
       link: function(scope,element,attrs,controller){
+        var hiddenTimer;
 
         if(!$rootScope.loadingModal) {
           var loadingHTML = $templateCache.get("template/zLoading/zLoading.html");
@@ -28,9 +29,10 @@ angular
           //  return;
           //}
           if(newValue&&newValue.constructor == Boolean) {
+            $timeout.cancel(hiddenTimer);
             $rootScope.loadingModal.show();
           } else {
-            $timeout(function() {
+            hiddenTimer = $timeout(function() {
               $rootScope.loadingModal.hide();
             }, 200);
           }


### PR DESCRIPTION
z-loading组件由隐藏变为显示时会清除上一次延迟隐藏的计时器，避免短时间内状态多次变化导致的加载中界面被错误隐藏的情况。
